### PR TITLE
fix(reporting): ensure endTime and duration are set on status update Closes #1

### DIFF
--- a/TrganTest.cs
+++ b/TrganTest.cs
@@ -105,7 +105,7 @@ public class TrganTest(TrganContainer container, string trgantestName, string[] 
     /// <param name="status"></param>
     public void Log(Status status) {
         Status = status;
-        testDetails.EndTime = DateTime.Now;
+        UpdateEndTimes();
     }
     /// <summary>
     /// Marks the test as PASS


### PR DESCRIPTION
This PR fixes the bug where `End Time` and `Duration` were not reflected in the Execution Status Table when using `test.Pass()` f or container based report.

Closes #1 



<img width="1072" height="202" alt="image" src="https://github.com/user-attachments/assets/a8ead6d4-7c50-42fa-9b2c-d4114b797c84" />
